### PR TITLE
Split build process per-platform

### DIFF
--- a/Builders/AndroidBuilder.cs
+++ b/Builders/AndroidBuilder.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Desktop.Deploy.Uploaders;
+
+namespace osu.Desktop.Deploy.Builders
+{
+    public class AndroidBuilder : Builder
+    {
+        private readonly string? codeSigningPassword;
+
+        public AndroidBuilder(string version, string? codeSigningPassword)
+            : base(version)
+        {
+            if (!string.IsNullOrEmpty(Program.AndroidCodeSigningCertPath))
+                this.codeSigningPassword = codeSigningPassword ?? Program.ReadLineMasked("Enter code signing password: ");
+        }
+
+        protected override string TargetFramework => "net8.0-android";
+        protected override string RuntimeIdentifier => "android-arm64";
+
+        public override Uploader CreateUploader() => new GitHubUploader();
+
+        public override void Build()
+        {
+            string codeSigningArguments = string.Empty;
+
+            if (!string.IsNullOrEmpty(Program.AndroidCodeSigningCertPath))
+            {
+                codeSigningArguments +=
+                    $" -p:AndroidKeyStore=true"
+                    + $" -p:AndroidSigningKeyStore={Program.AndroidCodeSigningCertPath}"
+                    + $" -p:AndroidSigningKeyAlias={Path.GetFileNameWithoutExtension(Program.AndroidCodeSigningCertPath)}"
+                    + $" -p:AndroidSigningKeyPass={codeSigningPassword}"
+                    + $" -p:AndroidSigningKeyStorePass={codeSigningPassword}";
+            }
+
+            string[] versionParts = Version.Split('.');
+            string versionCode = versionParts[0].PadLeft(4, '0') + versionParts[1].PadLeft(4, '0') + versionParts[2].PadLeft(1, '0');
+
+            RunDotnetPublish($"-p:ApplicationVersion={versionCode} {codeSigningArguments}");
+
+            File.Move(Path.Combine(Program.StagingPath, "sh.ppy.osulazer-Signed.apk"), Path.Combine(Program.ReleasesPath, "sh.ppy.osulazer.apk"), true);
+        }
+    }
+}

--- a/Builders/Builder.cs
+++ b/Builders/Builder.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Desktop.Deploy.Uploaders;
+
+namespace osu.Desktop.Deploy.Builders
+{
+    public abstract class Builder
+    {
+        protected abstract string TargetFramework { get; }
+        protected abstract string RuntimeIdentifier { get; }
+
+        protected string SplashImagePath => Path.Combine(Program.SolutionPath, "assets", "lazer-nuget.png");
+        protected string IconPath => Path.Combine(Program.SolutionPath, Program.ProjectName, Program.IconName);
+
+        protected readonly string Version;
+
+        protected Builder(string version)
+        {
+            Version = version;
+
+            refreshDirectory(Program.STAGING_FOLDER);
+        }
+
+        public abstract Uploader CreateUploader();
+
+        public abstract void Build();
+
+        protected void RunDotnetPublish(string? extraArgs = null, string? outputDir = null)
+        {
+            extraArgs ??= string.Empty;
+            outputDir ??= Program.StagingPath;
+
+            Program.RunCommand("dotnet", $"publish"
+                                         + $" -f {TargetFramework}"
+                                         + $" -r {RuntimeIdentifier}"
+                                         + $" -c Release"
+                                         + $" -o \"{outputDir}\""
+                                         + $" -p:Version={Version}"
+                                         + $" --self-contained"
+                                         + $" {extraArgs}"
+                                         + $" {Program.ProjectName}");
+        }
+
+        private static void refreshDirectory(string directory)
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/Builders/IOSBuilder.cs
+++ b/Builders/IOSBuilder.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Desktop.Deploy.Uploaders;
+
+namespace osu.Desktop.Deploy.Builders
+{
+    public class IOSBuilder : Builder
+    {
+        public IOSBuilder(string version)
+            : base(version)
+        {
+        }
+
+        protected override string TargetFramework => "net8.0-ios";
+        protected override string RuntimeIdentifier => "ios-arm64";
+
+        public override Uploader CreateUploader() => new GitHubUploader();
+
+        public override void Build()
+        {
+            RunDotnetPublish("-p:ApplicationDisplayVersion=1.0");
+
+            File.Move(Path.Combine(Program.StagingPath, "osu.iOS.app"), Path.Combine(Program.ReleasesPath, "osu.iOS.app"), true);
+        }
+    }
+}

--- a/Builders/LinuxBuilder.cs
+++ b/Builders/LinuxBuilder.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Desktop.Deploy.Uploaders;
+
+namespace osu.Desktop.Deploy.Builders
+{
+    public class LinuxBuilder : Builder
+    {
+        private const string app_dir = "osu!.AppDir";
+        private const string app_name = "osu!";
+        private const string os_name = "linux";
+
+        private readonly string stagingTarget;
+        private readonly string publishTarget;
+
+        public LinuxBuilder(string version)
+            : base(version)
+        {
+            stagingTarget = Path.Combine(Program.StagingPath, app_dir);
+            publishTarget = Path.Combine(stagingTarget, "usr", "bin");
+        }
+
+        protected override string TargetFramework => "net8.0";
+        protected override string RuntimeIdentifier => $"{os_name}-x64";
+
+        public override Uploader CreateUploader() => new VelopackUploader(app_name, os_name, RuntimeIdentifier, RuntimeIdentifier, stagingPath: stagingTarget);
+
+        public override void Build()
+        {
+            if (Directory.Exists(stagingTarget))
+                Directory.Delete(stagingTarget, true);
+            Directory.CreateDirectory(stagingTarget);
+
+            foreach (var file in Directory.GetFiles(Path.Combine(Program.TemplatesPath, app_dir)))
+                new FileInfo(file).CopyTo(Path.Combine(stagingTarget, Path.GetFileName(file)));
+
+            Program.RunCommand("chmod", $"+x {stagingTarget}/AppRun");
+
+            RunDotnetPublish(outputDir: publishTarget);
+        }
+    }
+}

--- a/Builders/MacOSBuilder.cs
+++ b/Builders/MacOSBuilder.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Desktop.Deploy.Uploaders;
+
+namespace osu.Desktop.Deploy.Builders
+{
+    public class MacOSBuilder : Builder
+    {
+        private const string app_name = "osu!";
+        private const string os_name = "mac";
+
+        public MacOSBuilder(string version, string? arch)
+            : base(version)
+        {
+            if (string.IsNullOrEmpty(arch))
+            {
+                Console.Write("Build for which architecture? [x64/arm64]: ");
+                arch = Console.ReadLine() ?? string.Empty;
+            }
+
+            if (arch != "x64" && arch != "arm64")
+                Logger.Error($"Invalid Architecture: {arch}");
+
+            RuntimeIdentifier = $"{os_name}-{arch}";
+        }
+
+        protected override string TargetFramework => "net8.0";
+        protected override string RuntimeIdentifier { get; }
+
+        public override Uploader CreateUploader()
+        {
+            string extraArgs = $" --icon=\"{IconPath}\"";
+
+            if (!string.IsNullOrEmpty(Program.AppleCodeSignCertName))
+                extraArgs += $" --signAppIdentity=\"{Program.AppleCodeSignCertName}\"";
+            if (!string.IsNullOrEmpty(Program.AppleInstallSignCertName))
+                extraArgs += $" --signInstallIdentity=\"{Program.AppleInstallSignCertName}\"";
+            if (!string.IsNullOrEmpty(Program.AppleNotaryProfileName))
+                extraArgs += $" --notaryProfile=\"{Program.AppleNotaryProfileName}\"";
+
+            return new VelopackUploader(app_name, os_name, RuntimeIdentifier, RuntimeIdentifier, extraArgs);
+        }
+
+        public override void Build() => RunDotnetPublish();
+    }
+}

--- a/Builders/WindowsBuilder.cs
+++ b/Builders/WindowsBuilder.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Desktop.Deploy.Uploaders;
+
+namespace osu.Desktop.Deploy.Builders
+{
+    public class WindowsBuilder : Builder
+    {
+        private const string app_name = "osu!.exe";
+        private const string os_name = "win";
+        private const string channel = "win";
+
+        private readonly string? codeSigningPassword;
+
+        public WindowsBuilder(string version, string? codeSigningPassword)
+            : base(version)
+        {
+            if (!string.IsNullOrEmpty(Program.WindowsCodeSigningCertPath))
+                this.codeSigningPassword = codeSigningPassword ?? Program.ReadLineMasked("Enter code signing password: ");
+        }
+
+        protected override string TargetFramework => "net8.0";
+        protected override string RuntimeIdentifier => $"{os_name}-x64";
+
+        public override Uploader CreateUploader()
+        {
+            string extraArgs = $" --splashImage=\"{SplashImagePath}\""
+                               + $" --icon=\"{IconPath}\"";
+
+            if (!string.IsNullOrEmpty(Program.WindowsCodeSigningCertPath))
+                extraArgs += $" --signParams=\"/td sha256 /fd sha256 /f {Program.WindowsCodeSigningCertPath} /p {codeSigningPassword} /tr http://timestamp.comodoca.com\"";
+
+            return new VelopackUploader(app_name, os_name, RuntimeIdentifier, channel, extraArgs: extraArgs);
+        }
+
+        public override void Build()
+        {
+            RunDotnetPublish();
+
+            bool rcEditCommand =
+                Program.RunCommand("tools/rcedit-x64.exe", $"\"{Path.Combine(Program.StagingPath, "osu!.exe")}\""
+                                                           + $" --set-icon \"{IconPath}\"",
+                    exitOnFail: false);
+
+            if (!rcEditCommand)
+            {
+                // Retry again with wine
+                // TODO: Should probably change this to use RuntimeInfo.OS checks instead of fail values
+                bool wineRcEditCommand =
+                    Program.RunCommand("wine", $"\"{Path.GetFullPath("tools/rcedit-x64.exe")}\""
+                                               + $" \"{Path.Combine(Program.StagingPath, "osu!.exe")}\""
+                                               + $" --set-icon \"{IconPath}\"",
+                        exitOnFail: false);
+
+                if (!wineRcEditCommand)
+                    Logger.Error("Failed to set icon on osu!.exe");
+            }
+        }
+    }
+}

--- a/Logger.cs
+++ b/Logger.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+
+namespace osu.Desktop.Deploy
+{
+    public static class Logger
+    {
+        private static readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
+        public static void Error(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"FATAL ERROR: {message}");
+            Console.ResetColor();
+
+            Program.PauseIfInteractive();
+            Environment.Exit(-1);
+        }
+
+        public static void Write(string message, ConsoleColor col = ConsoleColor.Gray)
+        {
+            if (stopwatch.ElapsedMilliseconds > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.Write(stopwatch.ElapsedMilliseconds.ToString().PadRight(8));
+            }
+
+            Console.ForegroundColor = col;
+            Console.WriteLine(message);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -150,6 +150,7 @@ namespace osu.Desktop.Deploy
                 if (targetPlatform == RuntimeInfo.Platform.macOS)
                 {
                     string targetArch = "";
+
                     if (args.Length > 3)
                     {
                         targetArch = args[3];
@@ -178,7 +179,11 @@ namespace osu.Desktop.Deploy
                 string rid = $"{os}-{arch}";
                 string channel = rid == "win-x64" ? "win" : rid;
 
-                if (canGitHub) runCommand("dotnet", $"vpk download github --repoUrl {GithubRepoUrl} --token {GitHubAccessToken} --channel {channel} -o=\"{releasesPath}\"", throwIfNonZero: false, useSolutionPath: false);
+                if (canGitHub)
+                {
+                    runCommand("dotnet", $"vpk download github --repoUrl {GithubRepoUrl} --token {GitHubAccessToken} --channel {channel} -o=\"{releasesPath}\"", throwIfNonZero: false,
+                        useSolutionPath: false);
+                }
 
                 if (targetPlatform == RuntimeInfo.Platform.Linux)
                 {
@@ -199,6 +204,7 @@ namespace osu.Desktop.Deploy
                 if (targetPlatform == RuntimeInfo.Platform.Windows)
                 {
                     bool rcEditCommand = runCommand("tools/rcedit-x64.exe", $"\"{Path.Combine(publishDir, "osu!.exe")}\" --set-icon \"{iconPath}\"", exitOnFail: false);
+
                     if (!rcEditCommand)
                     {
                         // Retry again with wine
@@ -236,8 +242,11 @@ namespace osu.Desktop.Deploy
                 runCommand("dotnet", $"vpk [{os}] pack -u {PackageName} -v {version} -r {rid} -o \"{releasesPath}\" -e \"{applicationName}\"  --channel={channel}{extraCmd}", useSolutionPath: false);
 
                 if (canGitHub && GitHubUpload)
+                {
                     runCommand("dotnet",
-                        $"vpk upload github --repoUrl {GithubRepoUrl} --token {GitHubAccessToken} -o\"{releasesPath}\" --tag {version} --releaseName {version} --merge --channel={channel}", useSolutionPath: false);
+                        $"vpk upload github --repoUrl {GithubRepoUrl} --token {GitHubAccessToken} -o\"{releasesPath}\" --tag {version} --releaseName {version} --merge --channel={channel}",
+                        useSolutionPath: false);
+                }
             }
             else if (targetPlatform == RuntimeInfo.Platform.Android)
             {
@@ -338,6 +347,7 @@ namespace osu.Desktop.Deploy
             Debug.Assert(targetRelease.UploadUrl != null);
 
             var assetUploadUrl = targetRelease.UploadUrl.Replace("{?name,label}", "?name={0}");
+
             foreach (var a in Directory.GetFiles(releases_folder).Reverse()) //reverse to upload RELEASES first.
             {
                 if (Path.GetFileName(a).StartsWith('.'))
@@ -442,6 +452,7 @@ namespace osu.Desktop.Deploy
                 p.WaitForExit();
 
                 if (p.ExitCode == 0) return true;
+
                 write(output);
             }
             catch (Exception e)

--- a/Uploaders/GitHubUploader.cs
+++ b/Uploaders/GitHubUploader.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using Newtonsoft.Json;
+using osu.Framework.IO.Network;
+
+namespace osu.Desktop.Deploy.Uploaders
+{
+    public class GitHubUploader : Uploader
+    {
+        public override void RestoreBuild()
+        {
+        }
+
+        public override void PublishBuild(string version)
+        {
+            var req = new JsonWebRequest<GitHubRelease>($"{Program.GitHubApiEndpoint}")
+            {
+                Method = HttpMethod.Post,
+            };
+
+            GitHubRelease? targetRelease = Program.GetLastGithubRelease(true);
+
+            if (targetRelease == null || targetRelease.TagName != version)
+            {
+                Logger.Write($"- Creating release {version}...", ConsoleColor.Yellow);
+                req.AddRaw(JsonConvert.SerializeObject(new GitHubRelease
+                {
+                    Name = version,
+                    Draft = true,
+                }));
+                req.AuthenticatedBlockingPerform();
+
+                targetRelease = req.ResponseObject;
+            }
+            else
+            {
+                Logger.Write($"- Adding to existing release {version}...", ConsoleColor.Yellow);
+            }
+
+            Debug.Assert(targetRelease.UploadUrl != null);
+
+            var assetUploadUrl = targetRelease.UploadUrl.Replace("{?name,label}", "?name={0}");
+
+            foreach (var a in Directory.GetFiles(Program.RELEASES_FOLDER).Reverse()) //reverse to upload RELEASES first.
+            {
+                if (Path.GetFileName(a).StartsWith('.'))
+                    continue;
+
+                Logger.Write($"- Adding asset {a}...", ConsoleColor.Yellow);
+                var upload = new WebRequest(assetUploadUrl, Path.GetFileName(a))
+                {
+                    Method = HttpMethod.Post,
+                    Timeout = 240000,
+                    ContentType = "application/octet-stream",
+                };
+
+                upload.AddRaw(File.ReadAllBytes(a));
+                upload.AuthenticatedBlockingPerform();
+            }
+        }
+    }
+}

--- a/Uploaders/Uploader.cs
+++ b/Uploaders/Uploader.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Desktop.Deploy.Uploaders
+{
+    public abstract class Uploader
+    {
+        public abstract void RestoreBuild();
+
+        public abstract void PublishBuild(string version);
+    }
+}

--- a/Uploaders/VelopackUploader.cs
+++ b/Uploaders/VelopackUploader.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Desktop.Deploy.Uploaders
+{
+    public class VelopackUploader : Uploader
+    {
+        private readonly string applicationName;
+        private readonly string operatingSystemName;
+        private readonly string runtimeIdentifier;
+        private readonly string channel;
+        private readonly string? extraArgs;
+        private readonly string stagingPath;
+
+        public VelopackUploader(string applicationName, string operatingSystemName, string runtimeIdentifier, string channel, string? extraArgs = null, string? stagingPath = null)
+        {
+            this.applicationName = applicationName;
+            this.operatingSystemName = operatingSystemName;
+            this.runtimeIdentifier = runtimeIdentifier;
+            this.channel = channel;
+            this.extraArgs = extraArgs;
+            this.stagingPath = stagingPath ?? Program.StagingPath;
+        }
+
+        public override void RestoreBuild()
+        {
+            if (Program.CanGitHub)
+            {
+                Program.RunCommand("dotnet", $"vpk download github"
+                                             + $" --repoUrl {Program.GitHubRepoUrl}"
+                                             + $" --token {Program.GitHubAccessToken}"
+                                             + $" --channel {channel}"
+                                             + $" -o=\"{Program.ReleasesPath}\"",
+                    throwIfNonZero: false,
+                    useSolutionPath: false);
+            }
+        }
+
+        public override void PublishBuild(string version)
+        {
+            Program.RunCommand("dotnet", $"vpk [{operatingSystemName}] pack"
+                                         + $" -u {Program.PackageName}"
+                                         + $" -v {version}"
+                                         + $" -r {runtimeIdentifier}"
+                                         + $" -o \"{Program.ReleasesPath}\""
+                                         + $" -e \"{applicationName}\""
+                                         + $" -p \"{stagingPath}\""
+                                         + $" --channel={channel}"
+                                         + $" {extraArgs}",
+                useSolutionPath: false);
+
+            if (Program.CanGitHub && Program.GitHubUpload)
+            {
+                Program.RunCommand("dotnet", $"vpk upload github"
+                                             + $" --repoUrl {Program.GitHubRepoUrl}"
+                                             + $" --token {Program.GitHubAccessToken}"
+                                             + $" -o\"{Program.ReleasesPath}\""
+                                             + $" --tag {version}"
+                                             + $" --releaseName {version}"
+                                             + $" --merge"
+                                             + $" --channel={channel}",
+                    useSolutionPath: false);
+            }
+        }
+    }
+}

--- a/Uploaders/VelopackUploader.cs
+++ b/Uploaders/VelopackUploader.cs
@@ -27,10 +27,10 @@ namespace osu.Desktop.Deploy.Uploaders
             if (Program.CanGitHub)
             {
                 Program.RunCommand("dotnet", $"vpk download github"
-                                             + $" --repoUrl {Program.GitHubRepoUrl}"
-                                             + $" --token {Program.GitHubAccessToken}"
-                                             + $" --channel {channel}"
-                                             + $" -o=\"{Program.ReleasesPath}\"",
+                                             + $" --repoUrl=\"{Program.GitHubRepoUrl}\""
+                                             + $" --token=\"{Program.GitHubAccessToken}\""
+                                             + $" --channel=\"{channel}\""
+                                             + $" --outputDir=\"{Program.ReleasesPath}\"",
                     throwIfNonZero: false,
                     useSolutionPath: false);
             }
@@ -39,26 +39,26 @@ namespace osu.Desktop.Deploy.Uploaders
         public override void PublishBuild(string version)
         {
             Program.RunCommand("dotnet", $"vpk [{operatingSystemName}] pack"
-                                         + $" -u {Program.PackageName}"
-                                         + $" -v {version}"
-                                         + $" -r {runtimeIdentifier}"
-                                         + $" -o \"{Program.ReleasesPath}\""
-                                         + $" -e \"{applicationName}\""
-                                         + $" -p \"{stagingPath}\""
-                                         + $" --channel={channel}"
+                                         + $" --packId=\"{Program.PackageName}\""
+                                         + $" --packVersion=\"{version}\""
+                                         + $" --runtime=\"{runtimeIdentifier}\""
+                                         + $" --outputDir=\"{Program.ReleasesPath}\""
+                                         + $" --mainExe=\"{applicationName}\""
+                                         + $" --packDir=\"{stagingPath}\""
+                                         + $" --channel=\"{channel}\""
                                          + $" {extraArgs}",
                 useSolutionPath: false);
 
             if (Program.CanGitHub && Program.GitHubUpload)
             {
                 Program.RunCommand("dotnet", $"vpk upload github"
-                                             + $" --repoUrl {Program.GitHubRepoUrl}"
-                                             + $" --token {Program.GitHubAccessToken}"
-                                             + $" -o\"{Program.ReleasesPath}\""
-                                             + $" --tag {version}"
-                                             + $" --releaseName {version}"
+                                             + $" --repoUrl=\"{Program.GitHubRepoUrl}\""
+                                             + $" --token=\"{Program.GitHubAccessToken}\""
+                                             + $" --outputDir=\"{Program.ReleasesPath}\""
+                                             + $" --tag=\"{version}\""
+                                             + $" --releaseName=\"{version}\""
                                              + $" --merge"
-                                             + $" --channel={channel}",
+                                             + $" --channel=\"{channel}\"",
                     useSolutionPath: false);
             }
         }


### PR DESCRIPTION
One of my biggest issues right now is that the main method is unreadable due to everything being bundled into it. I've split it out into individual `Builder`s and `Uploader`s.

While there are some logical changes, I've tried to avoid them as much as possible. As a result this PR makes no effort so far to fix e.g. the macOS build being broken.