### PR TITLE
Add `--packTitle` to pack command

### DIFF
--- a/Uploaders/VelopackUploader.cs
+++ b/Uploaders/VelopackUploader.cs
@@ -39,6 +39,7 @@ namespace osu.Desktop.Deploy.Uploaders
         public override void PublishBuild(string version)
         {
             Program.RunCommand("dotnet", $"vpk [{operatingSystemName}] pack"
+                                         + $" --packTitle=\"osu!\""
                                          + $" --packId=\"{Program.PackageName}\""
                                          + $" --packVersion=\"{version}\""
                                          + $" --runtime=\"{runtimeIdentifier}\""


### PR DESCRIPTION
In particular, this will correctly name the app bundle in the next velopack release (https://github.com/velopack/velopack/pull/211).